### PR TITLE
Update parameter_list.md

### DIFF
--- a/docs/src/parameter_list.md
+++ b/docs/src/parameter_list.md
@@ -1556,7 +1556,7 @@ Limits on exchange quantities. In the inheritance rules <em>sum*</em> only appli
 <tr>
 <td><strong>name</strong></td>
 <td>exc{Fix/Low/Up}</td>
-<td>ExcDir{Fix/Low/Up}</td>
+<td>excDir{Fix/Low/Up}</td>
 </tr>
 <tr>
 <td><strong>unit</strong></td>


### PR DESCRIPTION
 The parameter `ExcDir` is probably a typo in the documentation since this causes an "unkown parameter" error while `excDir` on the other hand just works just fine and is consistent with the naming of the other parameters.