### PR TITLE
added `using YAML` in the module definition

### DIFF
--- a/src/AnyMOD.jl
+++ b/src/AnyMOD.jl
@@ -20,6 +20,7 @@ module AnyMOD
 
     using Base.Threads, CSV, Dates, LinearAlgebra, Requires, DelimitedFiles
     using MathOptInterface, Reexport, Statistics, PyCall, SparseArrays, Suppressor
+    using YAML
     @reexport using DataFrames, JuMP, Dates, Suppressor
 
     pyimport_conda("networkx","networkx")


### PR DESCRIPTION
YAML was not loaded before and caused an error when calling `computeResults`